### PR TITLE
Feature: Specify range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 # already existing elements were commented out
 
 #/target
+
+**/.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,10 @@
       },
       "args": [
         "--font-file=~/Downloads/HELVETICANOWMTTEXT.OTF",
-        "--img-size=512"
+        "--img-size=52",
+        "--unicode-range-start=f030",
+        "--unicode-range-end=1e0030",
+        "--number-of-threads=1"
 
       ],
       "cwd": "${workspaceFolder}",

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,12 +22,20 @@ Changing the output color (in this case green):
 cargo run -- --font-file test.otf --color-red 0 --color-green 255 --color-blue 0
 ```
 
+Specify the range:
+
+```cmd
+cargo run -- --font-file test.otf --unicode-range-start 0x00 --unicode-range-end 0xffff
+```
+
+> NOTE: The values can be in the form of `0x####`, `U+####` or `####`.
+
 For more usage see: `cargo run -- --help`
 
 ## Optional Features
 
 By default the tool is built with parallel processing, controlled by `feature = "parallel"`.  To build without the parallel processing:
 
-```
+```cmd
 cargo build --no-default-features
 ```


### PR DESCRIPTION
Allow for the ability to specify the range of characters.  Since using `auto-args`, needed to define a new struct to parse a `char` from the cli arguments. 

Also fixed an issue with the file names, where the endianness was incorrect for a human readable order.